### PR TITLE
fix: remove events from button in overlay mode

### DIFF
--- a/.changeset/friendly-lies-heal.md
+++ b/.changeset/friendly-lies-heal.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': patch
+---
+
+Remove current events from button used to trigger the overlay modal to open. It's because the previous event might have the effect of changing the UI which can conflict with the modal transition.

--- a/src/interface/OverlayInterface.tsx
+++ b/src/interface/OverlayInterface.tsx
@@ -55,14 +55,15 @@ const OverlayInterface = () => {
           }
         };
 
+        // Remove all registered events
+        const cloneButton = button.cloneNode(true) as HTMLElement;
+        button.parentNode?.replaceChild(cloneButton, button);
+        button = cloneButton;
+
         if (!isButton(button) || !isSubmitInput(button)) {
           button.setAttribute('role', 'button');
           button.setAttribute('tabIndex', '0');
           button.setAttribute('aria-label', ariaLabel);
-          // Remove all registered events
-          const cloneButton = button.cloneNode(true) as HTMLElement;
-          button.parentNode?.replaceChild(cloneButton, button);
-          button = cloneButton;
 
           button.querySelectorAll('*').forEach((node) => {
             if (node instanceof HTMLElement) {


### PR DESCRIPTION
In the overlay mode, we bind the even on a node to trigger the modal to open but the search button in some themes has the effect of changing the UI, for instance, the search button in https://sajari-jens3.myshopify.com/ is used to toggle the search box view. In this case, it should ignore the past event and only enable the modal transition.