### PR TITLE
fix: add missing defaultOpen prop for overlay mode

### DIFF
--- a/.changeset/chilly-hornets-return.md
+++ b/.changeset/chilly-hornets-return.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': patch
+---
+
+Added `defaultOpen` for `overlay` mode.

--- a/src/interface/OverlayInterface.tsx
+++ b/src/interface/OverlayInterface.tsx
@@ -24,14 +24,15 @@ const OverlayInterface = () => {
   const { results, pageCount, clear } = useSearchContext();
   const { setQuery } = useQuery();
   const { setWidth, filtersShown } = useInterfaceContext();
-  const [open, setOpen] = useState(false);
   const tabsFilters = filters?.filter((props) => props.type === 'tabs') || [];
   const inputProps = options.input ?? {};
   const {
     buttonSelector: buttonSelectorProp = getPresetSelectorOverlayMode(preset),
     inputSelector,
     ariaLabel = 'Open search',
+    defaultOpen = false,
   } = options as SearchResultsOptions<'overlay'>;
+  const [open, setOpen] = useState(defaultOpen);
 
   useEffect(() => {
     const buttonSelectors = isArray(buttonSelectorProp) ? buttonSelectorProp : [buttonSelectorProp];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,6 +48,7 @@ export type SearchResultsOptions<M = Mode> = {
       buttonSelector?: string | string[];
       inputSelector?: string;
       ariaLabel?: string;
+      defaultOpen?: boolean;
     }
 );
 


### PR DESCRIPTION
Add support `defaultOpen` prop for the `overlay` mode. This update is needed if we want to toggle the overlay view in the Shopify builder.


![image](https://user-images.githubusercontent.com/12707960/112572830-9c281380-8e1d-11eb-9c03-de9ae6b4d9fc.png)
