### PR TITLE
fix: evaluate deploy script env

### DIFF
--- a/.changeset/thin-waves-speak.md
+++ b/.changeset/thin-waves-speak.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': patch
+---
+
+Evaluate DEPLOY_SCRIPT env when building

--- a/preact.config.js
+++ b/preact.config.js
@@ -10,7 +10,11 @@ export default {
    * @param {WebpackConfigHelpers} helpers - object with useful helpers for working with the webpack config.
    * @param {object} options - this is mainly relevant for plugins (will always be empty in the config), default to an empty object
    * */
-  webpack(config, env) {
+  webpack(config, env, helpers) {
+    const { DEPLOY_SCRIPT } = process.env;
+    const { plugin } = helpers.getPluginsByName(config, 'DefinePlugin')[0];
+    Object.assign(plugin.definitions, { 'process.env.DEPLOY_SCRIPT': JSON.stringify(DEPLOY_SCRIPT) });
+
     config.node.process = true;
 
     // Remove the hash on output files


### PR DESCRIPTION
# Must merge before releasing

The reason of this PR is because we want the `build` step to be used for preview on netlify with widget selector, whereas the `build:script` is used for production release (cdn script)