### PR TITLE
feat: add top input option for standard mode

### DIFF
--- a/.changeset/rude-dogs-judge.md
+++ b/.changeset/rude-dogs-judge.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': minor
+---
+
+Add support to display the search bar on top of the interface.

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -22,6 +22,7 @@ export function mergeProps(params: MergePropsParams): MergedSearchResultsProps {
     options: {
       input: {
         mode: 'instant',
+        position: 'aside',
       },
       results: {
         imageAspectRatio: {

--- a/src/interface/Options/index.tsx
+++ b/src/interface/Options/index.tsx
@@ -9,7 +9,11 @@ const Summary = styled(CoreSummary)`
   ${tw`text-lg`}
 `;
 
-export default () => {
+interface Props {
+  showToggleFilter?: boolean;
+}
+
+export default ({ showToggleFilter = true }: Props) => {
   const { options } = useSearchResultsContext();
   const { breakpoints } = useInterfaceContext();
   const md = Boolean(breakpoints.md);
@@ -25,7 +29,7 @@ export default () => {
 
         <ViewType size="sm" inline={md} />
 
-        <ToggleFilters />
+        {showToggleFilter && <ToggleFilters />}
       </div>
     </div>
   );

--- a/src/interface/StandardInterface.tsx
+++ b/src/interface/StandardInterface.tsx
@@ -16,20 +16,29 @@ const StandardInterface = () => {
   const { results } = useSearchContext();
   const { setWidth, filtersShown } = useInterfaceContext();
   const tabsFilters = filters?.filter((props) => props.type === 'tabs') || [];
+  const hideSidebar =
+    (filters?.filter((props) => props.type !== 'tabs') || []).length === 0 && options.input?.position === 'top';
   const { hide = false, ...inputProps } = options.input ?? {};
+  const topInput = options.input?.position === 'top';
 
   return (
     <React.Fragment>
       {syncURL !== 'none' ? <SyncStateQueryParams /> : null}
       <ResizeObserver onResize={(size) => setWidth(size.width)}>
         <div id={id} css={tw`space-y-6`}>
-          {results && <Options />}
+          {!hide && topInput && <Input {...inputProps} css={tw`w-full`} />}
+          {results && <Options showToggleFilter={!hideSidebar || !topInput} />}
 
           <div css={tw`flex`}>
             {results && (
-              <div css={[tw`transition-all duration-200`, filtersShown ? tw`pr-8 w-80` : tw`w-0 opacity-0`]}>
+              <div
+                css={[
+                  tw`transition-all duration-200`,
+                  filtersShown && !hideSidebar ? tw`pr-8 w-80` : tw`w-0 opacity-0`,
+                ]}
+              >
                 <div css={tw`w-72 space-y-6`}>
-                  {!hide && <Input {...inputProps} />}
+                  {!hide && !topInput && <Input {...inputProps} />}
 
                   {filters
                     ?.filter((props) => props.type !== 'tabs')
@@ -40,7 +49,7 @@ const StandardInterface = () => {
               </div>
             )}
 
-            <div css={[tw`flex-1 space-y-6`, filtersShown ? 'width: calc(100% - 20rem);' : tw`w-full`]}>
+            <div css={[tw`flex-1 space-y-6`, filtersShown && !hideSidebar ? 'width: calc(100% - 20rem);' : tw`w-full`]}>
               {tabsFilters.length > 0 ? tabsFilters.map((props) => <Filter {...props} key={props.name} />) : null}
 
               <Results {...options.results} />

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,10 +29,12 @@ export type SyncURLType = 'none' | 'replace' | 'push';
 
 type Mode = 'standard' | 'overlay';
 
+type InputPosition = 'top' | 'aside';
+
 export type SearchResultsOptions<M = Mode> = {
   resultsPerPage?: ResultsPerPageProps;
   sorting?: SortingProps;
-  input?: InputProps & { hide?: boolean };
+  input?: InputProps & { hide?: boolean; position?: InputPosition };
   results?: ResultsProps & { viewType?: ResultViewType };
   pagination?: PaginationProps;
   mode?: M;


### PR DESCRIPTION
Add an option to display the search bar on top of the interface. 

![image](https://user-images.githubusercontent.com/12707960/113401943-73c88800-93ce-11eb-8950-9be912a02582.png)

