### PR TITLE
fix: incorrect data-widget name for overlay

### DIFF
--- a/.changeset/bright-dolphins-boil.md
+++ b/.changeset/bright-dolphins-boil.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': patch
+---
+
+Fix incorrect widget name passed in `data-widget` for the `overlay` mode.

--- a/src/dev/app.ts
+++ b/src/dev/app.ts
@@ -43,9 +43,7 @@ export default () => {
 
   const convertJSON = (json: string, widget: WidgetType) =>
     `
-    <div data-widget-hide="${widget === 'overlay' || widget === 'search-input-binding'}" data-widget="${
-      widget === 'overlay' ? 'search-results' : widget
-    }">
+    <div data-widget-hide="${widget === 'overlay' || widget === 'search-input-binding'}" data-widget="${widget}">
       <script type="application/json">
         ${json}
       </script>
@@ -79,7 +77,7 @@ export default () => {
     preview.innerHTML = `${jsonData}${extra}`;
 
     codeHeader.innerText = `
-<div data-widget="${widget === 'overlay' ? 'search-results' : widget}">
+<div data-widget="${widget}">
   <script type="application/json">`.trim();
 
     codeFooter.innerText = `

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ if (!process.env.DEPLOY_SCRIPT) {
 
 const components: Record<string, ComponentType> = {
   'search-results': SearchResults as ComponentType,
+  overlay: SearchResults as ComponentType,
   'search-input-binding': SearchInputBinding as ComponentType,
   'search-input': SearchInput as ComponentType,
 };


### PR DESCRIPTION
Currently, the value of `data-widget` for the overlay mode is `search-results` which is incorrect. This change aims to fix the name to `overlay`:

**Before**

<img width="755" alt="Screen Shot 2021-04-04 at 4 28 13 PM" src="https://user-images.githubusercontent.com/12707960/113504515-cb97f800-9562-11eb-9155-060bf02367b6.png">

**After**
![image](https://user-images.githubusercontent.com/12707960/113504580-31847f80-9563-11eb-8d7e-ec6fcf486b33.png)
