### PR TITLE
fix: add support importantStyles

### DIFF
--- a/.changeset/new-pumas-allow.md
+++ b/.changeset/new-pumas-allow.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': patch
+---
+
+Support `importantStyles` option to add !important to the provided styles in order to avoid CSS crashes from external CSS.

--- a/src/hooks/useSearchProviderProps/index.ts
+++ b/src/hooks/useSearchProviderProps/index.ts
@@ -21,6 +21,7 @@ export function useSearchProviderProps(props: SearchResultsProps) {
     preset,
     customClassNames,
     disableDefaultStyles = false,
+    importantStyles = false,
   } = props;
 
   const id = `search-ui-${Date.now()}`;
@@ -119,5 +120,6 @@ export function useSearchProviderProps(props: SearchResultsProps) {
     emitter,
     customClassNames,
     disableDefaultStyles,
+    importantStyles,
   };
 }

--- a/src/search-results.tsx
+++ b/src/search-results.tsx
@@ -21,6 +21,7 @@ export default (defaultProps: SearchResultsProps) => {
     viewType,
     customClassNames,
     disableDefaultStyles,
+    importantStyles,
   } = useSearchProviderProps(state);
 
   const emitterContext = {
@@ -54,6 +55,7 @@ export default (defaultProps: SearchResultsProps) => {
       viewType={viewType}
       customClassNames={customClassNames}
       disableDefaultStyles={disableDefaultStyles}
+      importantStyles={importantStyles}
     >
       <PubSubContextProvider value={emitterContext}>
         <SearchResultsContextProvider value={context}>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -80,6 +80,7 @@ export interface SearchResultsProps {
   theme: ContextProviderValues['theme'];
   customClassNames?: ContextProviderValues['customClassNames'];
   disableDefaultStyles?: ContextProviderValues['disableDefaultStyles'];
+  importantStyles?: ContextProviderValues['importantStyles'];
   options?: SearchResultsOptions;
   emitter: Emitter;
 }


### PR DESCRIPTION
Add support [`importantStyles`](https://react.docs.sajari.com/styling#important-styles) option to add `!important` to the provided styles in order to avoid CSS crashes from external CSS.