### PR TITLE
fix: venture theme takeover input

### DIFF
--- a/.changeset/poor-fireants-own.md
+++ b/.changeset/poor-fireants-own.md
@@ -2,4 +2,4 @@
 '@sajari/search-widgets': patch
 ---
 
-Fix the takeover input not working in Venture theme
+Prevent Shopify theme's dropdown to overlap with ours

--- a/src/search-input-binding.tsx
+++ b/src/search-input-binding.tsx
@@ -18,9 +18,8 @@ const attributesToBeRemoved = [
 const removeAttributes = (element: Element | null) =>
   attributesToBeRemoved.forEach((attr) => element?.removeAttribute(attr));
 
-const removeThemeOriginalDropdown = (elementSelectorToBeRemoved: string | string[]) => {
-  const selectors =
-    typeof elementSelectorToBeRemoved === 'string' ? elementSelectorToBeRemoved.split(' ') : elementSelectorToBeRemoved;
+const removeThemeElements = (selectorsParam: string | string[]) => {
+  const selectors = typeof selectorsParam === 'string' ? selectorsParam.split(' ') : selectorsParam;
   selectors.forEach((selector) => {
     const list = document.querySelectorAll(selector);
     list.forEach((element) => element.remove());
@@ -95,7 +94,7 @@ const renderBindingInput = (targets: NodeListOf<HTMLElement>, props: Omit<Search
   });
 };
 
-export default ({ selector: selectorProp, dropdownQuerySelector, ...rest }: SearchInputBindingProps) => {
+export default ({ selector: selectorProp, omittedElementSelectors, ...rest }: SearchInputBindingProps) => {
   let targets: NodeListOf<HTMLElement> | null = null;
   let selector = selectorProp;
   if (!selectorProp) {
@@ -104,7 +103,9 @@ export default ({ selector: selectorProp, dropdownQuerySelector, ...rest }: Sear
   targets = document.querySelectorAll(selector);
 
   if (targets && targets.length > 0) {
-    removeThemeOriginalDropdown(dropdownQuerySelector ?? []);
+    if (omittedElementSelectors) {
+      removeThemeElements(omittedElementSelectors);
+    }
     renderBindingInput(targets, rest);
   }
   return null;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -108,7 +108,7 @@ export interface InterfaceContextProps {
 export interface SearchInputBindingProps extends SearchResultsProps {
   selector: string;
   mode: InputMode;
-  dropdownQuerySelector?: string | string[];
+  omittedElementSelectors?: string | string[];
 }
 
 export type WidgetType = 'search-results' | 'search-input-binding' | 'overlay' | 'search-input';


### PR DESCRIPTION
## The original problem

Some themes come with their own dropdown design (Debut is an example, see image below). To be able to only show Sajari's dropdown we need to remove the input element's event listeners so that it doesn't trigger the original dropdown.
![Screen Shot 2021-04-29 at 16 37 43](https://user-images.githubusercontent.com/25856620/116531338-45749480-a909-11eb-8ff4-5bb80ecff4b3.png)

By doing that we accidentally broke another theme (Venture) because it relies on the event listener to show the input itself

## What this PR does

Instead of cloning the element, we keep the original one and take a different approach. Now we'll remove the original dropdown entirely.
