### PR TITLE
fix: set default importantStyles to avoid style override

### DIFF
--- a/.changeset/wet-boats-fetch.md
+++ b/.changeset/wet-boats-fetch.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': patch
+---
+
+Set default `importantStyles:true` for `Shopify` preset to avoid style override.

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -104,6 +104,7 @@ export function mergeProps(params: MergePropsParams): MergedSearchResultsProps {
           },
           syncURL: 'push',
         },
+        importantStyles: true,
       });
       break;
 

--- a/src/hooks/useSearchProviderProps/index.ts
+++ b/src/hooks/useSearchProviderProps/index.ts
@@ -19,13 +19,17 @@ export function useSearchProviderProps(props: SearchResultsProps) {
     theme,
     emitter,
     preset,
-    customClassNames,
-    disableDefaultStyles = false,
-    importantStyles = false,
   } = props;
 
   const id = `search-ui-${Date.now()}`;
-  const { fields, options, tracking } = mergeProps({ id, ...props });
+  const {
+    fields,
+    options,
+    tracking,
+    customClassNames,
+    disableDefaultStyles = false,
+    importantStyles = false,
+  } = mergeProps({ id, ...props });
   const { name, version = undefined } = isString(pipeline) ? { name: pipeline } : pipeline;
   const params = options.mode === 'standard' && options?.syncURL === 'none' ? {} : getSearchParams();
 


### PR DESCRIPTION
The only way to avoid style override is to have high specificity applied to the components. This PR enables `importantStyles` for `Shopify` preset so our CSS will come with `!important` which will prevent the widget styles from being overridden by Shopify theme CSS.