### PR TITLE
fix: improve auto scroll top UX for mobile overlay

### DIFF
--- a/.changeset/funny-clocks-whisper.md
+++ b/.changeset/funny-clocks-whisper.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': patch
+---
+
+Improve UX for the mobile overlay by automatically scrolling to top if the pagination or apply filters button was used.

--- a/src/interface/Options/index.tsx
+++ b/src/interface/Options/index.tsx
@@ -56,6 +56,7 @@ const Summary = styled(CoreSummary)`
 interface Props {
   showToggleFilter?: boolean;
   isMobile?: boolean;
+  onScrollTop?: () => void;
 }
 
 const FilterWatcher = ({ name, toggleIsActive }: { name: string; toggleIsActive: (v: boolean) => void }) => {
@@ -101,7 +102,7 @@ const FilterWatchers = ({
   );
 };
 
-export default ({ showToggleFilter = true, isMobile = false }: Props) => {
+export default ({ showToggleFilter = true, isMobile = false, onScrollTop }: Props) => {
   const { options, filters, filterBuilders } = useSearchResultsContext();
   const { breakpoints } = useInterfaceContext();
   const { resetFilters, results } = useSearchContext();
@@ -239,7 +240,16 @@ export default ({ showToggleFilter = true, isMobile = false }: Props) => {
             >
               {`Clear (${count})`}
             </Button>
-            <Button onClick={onClose} appearance="primary" css={tw`w-1/2`}>
+            <Button
+              onClick={() => {
+                onClose();
+                if (onScrollTop) {
+                  onScrollTop();
+                }
+              }}
+              appearance="primary"
+              css={tw`w-1/2`}
+            >
               Apply
             </Button>
           </ModalFooter>

--- a/src/interface/OverlayInterface.tsx
+++ b/src/interface/OverlayInterface.tsx
@@ -5,7 +5,7 @@ import { Filter, Input, Pagination, Results, useSearchUIContext } from '@sajari/
 // TODO: ideally this should be a generic solution in the Modal component
 // making a note here so we (Thanh) can revisit the issue
 import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
-import { useEffect, useState } from 'preact/hooks';
+import { useCallback, useEffect, useState } from 'preact/hooks';
 import tw from 'twin.macro';
 
 import { useSearchResultsContext } from '../context';
@@ -22,6 +22,8 @@ function isButton(node: Element) {
   return node.tagName === 'BUTTON' || node.getAttribute('role') === 'button';
 }
 
+const containerId = `sj-${Date.now()}`;
+
 const OverlayInterface = () => {
   const { options, filters, id, preset } = useSearchResultsContext();
   const { results, pageCount, clear, resetFilters } = useSearchContext();
@@ -31,7 +33,12 @@ const OverlayInterface = () => {
   const tabsFilters = filters?.filter((props) => props.type === 'tabs') || [];
   const nonTabsFilters = filters?.filter((props) => props.type !== 'tabs') || [];
   const inputProps = options.input ?? {};
-  let refResultBox: HTMLDivElement | null;
+  let refResultBox: HTMLDivElement | undefined;
+
+  const scrollTop = useCallback(() => {
+    const container = document.querySelector(`#${containerId}`);
+    container?.scrollTo({ top: 0, behavior: 'smooth' });
+  }, []);
 
   const {
     buttonSelector: buttonSelectorProp = getPresetSelectorOverlayMode(preset),
@@ -160,7 +167,7 @@ const OverlayInterface = () => {
 
             {results && (
               <div css={[tw`pt-3.5 px-6`, isMobile ? tw`pb-2` : tw`pb-6`]}>
-                <Options isMobile={isMobile} showToggleFilter={!hideSidebar} />
+                <Options isMobile={isMobile} showToggleFilter={!hideSidebar} onScrollTop={scrollTop} />
               </div>
             )}
           </div>
@@ -205,6 +212,7 @@ const OverlayInterface = () => {
                 ) : null}
 
                 <div
+                  id={containerId}
                   css={tw`overflow-y-auto pt-6 pr-6`}
                   ref={(node) => {
                     if (!node) return;
@@ -221,7 +229,7 @@ const OverlayInterface = () => {
           ) : null}
           {pageCount > 1 ? (
             <div css={tw`flex-none border-0 border-t border-solid border-gray-200 py-3.5 px-6`}>
-              <Pagination {...options.pagination} />
+              <Pagination {...options.pagination} scrollTarget={`#${containerId}`} />
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
Improve UX for the mobile overlay by automatically scrolling to top if the pagination or apply filters button was used.

Demo: https://www.loom.com/share/0c61ccdbd4bd42fd805eb2d03998e2b6