### PR TITLE
fix: stop click event from being fired on parent node

### DIFF
--- a/.changeset/twelve-cows-jog.md
+++ b/.changeset/twelve-cows-jog.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': patch
+---
+
+Stop the click event from being triggered on the parent nodes. In most cases, we only want the click on the node (buttonSelector) to trigger the overlay modal to open rather than calling the script from themes.

--- a/src/interface/OverlayInterface.tsx
+++ b/src/interface/OverlayInterface.tsx
@@ -63,6 +63,7 @@ const OverlayInterface = () => {
           return;
         }
         e.preventDefault();
+        e.stopPropagation();
 
         setOpen(true);
         const query = input?.value;


### PR DESCRIPTION
Stop the click event from being triggered on the parent nodes. In most cases, we only want the click on the node (buttonSelector) to trigger the overlay modal to open rather than calling the script from themes. 

The issue was recorded while testing the Prestige theme:

- Before: https://www.loom.com/share/d04c3b83aa2548f38448b9e2715f220c
- After: https://www.loom.com/share/d02762c1f94a443690e8f66bbda61e57