### PR TITLE
fix: missing syncURL in default options of website collection

### DIFF
--- a/.changeset/cold-birds-yawn.md
+++ b/.changeset/cold-birds-yawn.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': patch
+---
+
+Set `syncURL: 'push'` for website collection to fix the issue when the query params from the URL are not synced with the UI.

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -117,6 +117,9 @@ export function mergeProps(params: MergePropsParams): MergedSearchResultsProps {
     case 'website': {
       const src: DeepPartial<MergedSearchResultsProps> = {
         tracking: new ClickTracking(),
+        options: {
+          syncURL: 'push',
+        },
       };
 
       merge(mergeOptions, props, src);


### PR DESCRIPTION
Set `syncURL: 'push'` for website collection to fix the issue when the query params from the URL are not synced with the UI.