### PR TITLE
fix: undefined appears in the url for a manual filter

### DIFF
--- a/.changeset/ninety-flowers-repeat.md
+++ b/.changeset/ninety-flowers-repeat.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': patch
+---
+
+Fix the issue when `undefined` appears in the URL if selecting a value from a manual filter.

--- a/src/hooks/useSearchProviderProps/index.ts
+++ b/src/hooks/useSearchProviderProps/index.ts
@@ -64,13 +64,14 @@ export function useSearchProviderProps(props: SearchResultsProps) {
 
   const filters = useMemo(() => {
     return filtersProp.map((filter) => {
-      const value = params[filter.field as string] || '';
+      const key = filter.field || filter.name;
+      const value = params[key] || '';
       const isRangeFilter = filter.type === 'range';
       const filterBuilder = isRangeFilter ? new RangeFilterBuilder(filter) : new FilterBuilder(filter);
 
       if (filterBuilder instanceof RangeFilterBuilder) {
         const initialRange = paramToRange(value);
-        const limit = (params[`${filter.field}_min_max` as string] || '').split(':').map(Number) as Range;
+        const limit = (params[`${key}_min_max`] || '').split(':').map(Number) as Range;
         if (isRange(initialRange)) {
           filterBuilder.set(initialRange as Range);
         }

--- a/src/interface/SyncStateQueryParams.tsx
+++ b/src/interface/SyncStateQueryParams.tsx
@@ -18,7 +18,7 @@ import { SearchResultsOptions } from '../types';
 import { isRange, paramToRange, rangeToParam } from '../utils';
 
 const FilterWatcher = ({ filter, replace }: { filter: FilterBuilder; replace: boolean }) => {
-  const key = filter.getField() as string;
+  const key = filter.getField() || filter.getName();
   const name = filter.getName();
   const { setSelected, selected } = useFilter(name);
   const setFilterParam = useSetQueryParams(key, {
@@ -39,7 +39,7 @@ const FilterWatcher = ({ filter, replace }: { filter: FilterBuilder; replace: bo
 };
 
 const RangeFilterWatcher = ({ filter, replace }: { filter: RangeFilterBuilder; replace: boolean }) => {
-  const key = filter.getField() as string;
+  const key = filter.getField() || filter.getName();
   const name = filter.getName();
   const { range, setRange, min, max } = useRangeFilter(name);
   const allowSetParam = useRef(false);


### PR DESCRIPTION
Resolve https://sajari.atlassian.net/browse/SF-426. The issue happens because it looks for the value of field `field` from the filter but it doesn’t exist if it is a manual filter. For example:

```json
{
    "title":"Filter Results",
    "name":"Refine",
    "type":"list",
    "count":false,
    "multi":false,
    "format":"default",
    "array":false,
    "sort":"none",
    "hideCount":true,
    "options":{
       "Vault":"dir1 = 'vault'",
       "Announcements":"dir1='announcements' OR (dir1='vault' AND dir2='announcements')",
       "Corporate Documents":"dir2 ~ 'corporate'",
       "Fees":"url ~ 'fees'",
       "Policy":"url ~ 'policy'"
    }
 }
```

In that case, fix it up by falling back to the value of the`name` field.