### PR TITLE
feat: add support for currency configuration

### DIFF
--- a/.changeset/spicy-oranges-enjoy.md
+++ b/.changeset/spicy-oranges-enjoy.md
@@ -1,0 +1,15 @@
+---
+'@sajari/search-widgets': minor
+---
+
+Add configuration for currency code to format any price values.
+
+```JSON
+{
+   "account": "1594153711901724220",
+   "collection": "bestbuy",
+   "pipeline": "query",
+   "currency": "USD",
+   ...
+}
+```

--- a/src/hooks/useSearchProviderProps/index.ts
+++ b/src/hooks/useSearchProviderProps/index.ts
@@ -19,6 +19,7 @@ export function useSearchProviderProps(props: SearchResultsProps) {
     theme,
     emitter,
     preset,
+    currency,
   } = props;
 
   const id = `search-ui-${Date.now()}`;
@@ -126,5 +127,6 @@ export function useSearchProviderProps(props: SearchResultsProps) {
     customClassNames,
     disableDefaultStyles,
     importantStyles,
+    currency,
   };
 }

--- a/src/search-input-binding.tsx
+++ b/src/search-input-binding.tsx
@@ -32,7 +32,7 @@ const onSelectHandler = (element: Element | null) => () => {
 };
 
 const Wrapper = ({ children, ...props }: Omit<SearchInputBindingProps, 'selector'> & { children: React.ReactNode }) => {
-  const { searchOnLoad, viewType, defaultFilter, theme, searchContext } = useSearchProviderProps(props);
+  const { searchOnLoad, viewType, defaultFilter, theme, searchContext, currency } = useSearchProviderProps(props);
 
   return (
     <SearchProvider
@@ -41,6 +41,7 @@ const Wrapper = ({ children, ...props }: Omit<SearchInputBindingProps, 'selector
       searchOnLoad={searchOnLoad}
       defaultFilter={defaultFilter}
       viewType={viewType}
+      currency={currency}
     >
       {children}
     </SearchProvider>

--- a/src/search-input.tsx
+++ b/src/search-input.tsx
@@ -7,9 +7,16 @@ import PubSubContextProvider from './pubsub/context';
 import { SearchInputProps } from './types';
 
 export default (defaultProps: SearchInputProps) => {
-  const { emitter, context, searchContext, theme, searchOnLoad, defaultFilter, viewType } = useSearchProviderProps(
-    defaultProps,
-  );
+  const {
+    emitter,
+    context,
+    searchContext,
+    theme,
+    searchOnLoad,
+    defaultFilter,
+    viewType,
+    currency,
+  } = useSearchProviderProps(defaultProps);
 
   const emitterContext = {
     emitter,
@@ -39,6 +46,7 @@ export default (defaultProps: SearchInputProps) => {
       theme={theme}
       searchOnLoad={searchOnLoad}
       defaultFilter={defaultFilter}
+      currency={currency}
       viewType={viewType}
     >
       <PubSubContextProvider value={emitterContext}>

--- a/src/search-results.tsx
+++ b/src/search-results.tsx
@@ -22,6 +22,7 @@ export default (defaultProps: SearchResultsProps) => {
     customClassNames,
     disableDefaultStyles,
     importantStyles,
+    currency,
   } = useSearchProviderProps(state);
 
   const emitterContext = {
@@ -56,6 +57,7 @@ export default (defaultProps: SearchResultsProps) => {
       customClassNames={customClassNames}
       disableDefaultStyles={disableDefaultStyles}
       importantStyles={importantStyles}
+      currency={currency}
     >
       <PubSubContextProvider value={emitterContext}>
         <SearchResultsContextProvider value={context}>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -81,6 +81,7 @@ export interface SearchResultsProps {
   customClassNames?: ContextProviderValues['customClassNames'];
   disableDefaultStyles?: ContextProviderValues['disableDefaultStyles'];
   importantStyles?: ContextProviderValues['importantStyles'];
+  currency?: ContextProviderValues['currency'];
   options?: SearchResultsOptions;
   emitter: Emitter;
 }


### PR DESCRIPTION
Add configuration for currency code to format any price values.

```JSON
{
   "account": "1594153711901724220",
   "collection": "bestbuy",
   "pipeline": "query",
   "currency": "USD",
   ...
}
```