### PR TITLE
fix: point v1 of loader to v2 of bundle

### DIFF
--- a/.changeset/dull-parrots-speak.md
+++ b/.changeset/dull-parrots-speak.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': patch
+---
+
+Due to an incident from a major bump, we’d want the loader CDN link v1 to point to v2 of the bundle (so that existing users won’t have to update the CDN link).


### PR DESCRIPTION
Due to an incident from a major bump, we’d want the loader CDN link v1 to point to v2 of the bundle (so that existing users won’t have to update the CDN link).