### PR TITLE
feat: add support for app collections

### DIFF
--- a/.changeset/chilled-moons-hide.md
+++ b/.changeset/chilled-moons-hide.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': minor
+---
+
+Add support for app collections.

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -163,6 +163,7 @@ export function mergeProps(params: MergePropsParams): MergedSearchResultsProps {
       merge(mergeOptions, props, src);
       break;
     }
+    case 'app':
     case 'website': {
       const src: DeepPartial<MergedSearchResultsProps> = {
         tracking: new ClickTracking(),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,7 +58,7 @@ export type SearchResultsOptions<M = Mode> = {
     }
 );
 
-export type PresetType = 'shopify' | 'website' | undefined;
+export type PresetType = 'shopify' | 'website' | 'app' | undefined;
 export type TrackingType = 'posneg' | 'click';
 
 export interface SearchResultsProps {


### PR DESCRIPTION
Add support for app collections. It uses the same default config as a website collection.