### PR TITLE
SF-458 feat: allow an alternative clickTokenURL to be provided for testing

### DIFF
--- a/.changeset/weak-dolphins-cough.md
+++ b/.changeset/weak-dolphins-cough.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': minor
+---
+
+feat: allow an alternative clickTokenURL to be provided for testing purposes

--- a/src/hooks/useSearchProviderProps/index.ts
+++ b/src/hooks/useSearchProviderProps/index.ts
@@ -21,6 +21,7 @@ export function useSearchProviderProps(props: SearchResultsProps) {
     preset,
     currency,
     config,
+    clickTokenURL,
   } = props;
 
   const id = `search-ui-${Date.now()}`;
@@ -98,6 +99,7 @@ export function useSearchProviderProps(props: SearchResultsProps) {
           account,
           collection,
           endpoint,
+          clickTokenURL,
         },
         { name, version },
         // TODO: note it here if we can resolve the issue

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -63,6 +63,7 @@ export type TrackingType = 'posneg' | 'click';
 
 export interface SearchResultsProps {
   endpoint?: string;
+  clickTokenURL?: string;
   account: string;
   collection: string;
   pipeline: string | { name: string; version?: string };


### PR DESCRIPTION
This works on the JS side but not the server side for the moment. Once tracking works in staging we can use this to test tracking changes without having to deploy.