### PR TITLE
feat: support Shopify collection filter

### DIFF
--- a/.changeset/serious-ants-thank.md
+++ b/.changeset/serious-ants-thank.md
@@ -1,0 +1,18 @@
+---
+'@sajari/search-widgets': minor
+---
+
+Support `shopifyOptions` for Search Result Widget to determine whether to pull results for a specific collection.
+
+```html
+<div data-widget="search-results">
+  <script type="application/json">
+    {
+      "shopifyOptions": {
+        "collectionHandle": "{{collection.handle}}",
+        "collectionId": "{{collection.id}}"
+      }
+    }
+  </script>
+</div>
+```

--- a/documentation/configuration-reference.md
+++ b/documentation/configuration-reference.md
@@ -40,10 +40,11 @@ The above configuration properties are defined based on the following structure:
 
 The search result widget displays search results to the user on a search result page. The following options can be configured when creating the search results widget.
 
-| Name      | Type                                            | Default | Description                                                                                                  |
-| --------- | ----------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------ |
-| `filters` | [`Filter[]`](#filter)                           | `_`     | Define a list of active filters. The configuration is specified as an array of [Filter](#filter) properties. |
-| `options` | [`SearchResultsOptions`](#searchresultsoptions) | `_`     | Specific configuration options.                                                                              |
+| Name             | Type                                            | Default | Description                                                                                                  |
+| ---------------- | ----------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------ |
+| `filters`        | [`Filter[]`](#filter)                           | `_`     | Define a list of active filters. The configuration is specified as an array of [Filter](#filter) properties. |
+| `options`        | [`SearchResultsOptions`](#searchresultsoptions) | `_`     | Specific configuration options.                                                                              |
+| `shopifyOptions` | [`ShopifyOptions`](#shopifyoptions)             | `_`     | Specific configuration options for `Shopify` preset.                                                         |
 
 ### Filter
 
@@ -298,13 +299,20 @@ See the example in [Codesandbox](https://codesandbox.io/s/range-filter-ctbvf).
 | `pagination`     | `PaginationProps`                                              | `_`                                                                                          | Options of Pagination component allowing the user to change the current page. See [Pagination props](https://react.docs.sajari.com/components/pagination#props).                                                   |
 | `mode`           | [`'standard'`](#standard-mode) \| [`'overlay'`](#overlay-mode) | `'standard'`                                                                                 | Control the display of the search results. While the `standard` mode is for displaying the search results on a page content, the `overlay` mode places the search results in the middle of an overlay screen.      |
 
+### ShopifyOptions
+
+| Name               | Type     | Default | Description                                                                                                                                                                                                                          |
+| ------------------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `collectionHandle` | `string` | `_`     | If the handle is `all`, it will look for results from the default collection. Otherwise, only retrive results for the collection which the id is `collectionId`. See [Object handles](https://shopify.dev/api/liquid/basics/handle). |
+| `collectionId`     | `string` | `_`     | The id of a Shopify collection. See [Collection id](https://shopify.dev/api/liquid/objects/collection#collection-id).                                                                                                                |
+
 #### Standard properties
 
 Exclusive props if mode is `standard`.
 
 | Name        | Type                                | Default    | Description                                                                                                                                                         |
 | ----------- | ----------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `'syncURL'` | `'none'` \| `'replace'` \| `'push'` | `'push'`   | Keep the search state in the URL if the option is not `none`. While `replace` prevent adding a new URL entry into the `history` stack, `push` will do the opposite. |
+| `syncURL`   | `'none'` \| `'replace'` \| `'push'` | `'push'`   | Keep the search state in the URL if the option is not `none`. While `replace` prevent adding a new URL entry into the `history` stack, `push` will do the opposite. |
 | `urlParams` | `{q: string}`                       | `{q: 'q'}` | A key -> value pair object maps the URL params to initial values for the search. `q` defines the URL param for the initial search query.                            |
 
 <details>

--- a/src/hooks/useSearchProviderProps/index.ts
+++ b/src/hooks/useSearchProviderProps/index.ts
@@ -1,3 +1,4 @@
+import { isNullOrUndefined } from '@sajari/react-sdk-utils';
 import { FilterBuilder, Pipeline, Range, RangeFilterBuilder, ResultViewType, Variables } from '@sajari/react-search-ui';
 import { useMemo } from 'react';
 
@@ -13,7 +14,7 @@ export function useSearchProviderProps(props: SearchResultsProps) {
     collection,
     pipeline,
     filters: filtersProp = [],
-    defaultFilter,
+    defaultFilter: defaultFilterProp,
     variables: variablesProp,
     theme,
     emitter,
@@ -21,6 +22,7 @@ export function useSearchProviderProps(props: SearchResultsProps) {
     currency,
     config,
     clickTokenURL,
+    shopifyOptions,
   } = props;
 
   const id = `search-ui-${Date.now()}`;
@@ -34,6 +36,23 @@ export function useSearchProviderProps(props: SearchResultsProps) {
   } = mergeProps({ id, ...props });
   const { name, version = undefined } = getPipelineInfo(pipeline);
   const params = options.mode === 'standard' && options?.syncURL === 'none' ? {} : getSearchParams();
+
+  const defaultFilter = useMemo(() => {
+    if (
+      preset === 'shopify' &&
+      !isNullOrUndefined(shopifyOptions?.collectionHandle) &&
+      shopifyOptions?.collectionHandle !== 'all' &&
+      !isNullOrUndefined(shopifyOptions?.collectionId)
+    ) {
+      const collectionFilter = `collection_ids ~ ['${shopifyOptions?.collectionId}']`;
+      if (defaultFilterProp) {
+        return `(${defaultFilterProp}) AND ${collectionFilter}`;
+      }
+      return collectionFilter;
+    }
+
+    return defaultFilterProp;
+  }, []);
 
   const viewType: ResultViewType = ['grid', 'list'].includes(params.viewType)
     ? (params.viewType as ResultViewType)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -85,10 +85,16 @@ export type SearchResultsOptions<M = SearchResultsMode> = {
     }
 );
 
+interface ShopifyOptions {
+  collectionHandle?: string;
+  collectionId?: string;
+}
+
 export interface SearchResultsProps extends SearchWidgetBaseOptions {
   filters?: Array<FilterProps & { field: string; textTransform?: TextTransform }>;
   options?: SearchResultsOptions;
   emitter: Emitter;
+  shopifyOptions?: ShopifyOptions;
 }
 
 export interface SearchResultsContextProps


### PR DESCRIPTION
Support `shopifyOptions` for Search Result Widget to determine whether to pull results for a specific collection.

```html
<div data-widget="search-results">
  <script type="application/json">
    {
      "shopifyOptions": {
        "collectionHandle": "{{collection.handle}}",
        "collectionId": "{{collection.id}}"
      }
    }
  </script>
</div>
```