### PR TITLE
chore: quick fix for global box-sizing override

### DIFF
--- a/.changeset/tough-snails-drive.md
+++ b/.changeset/tough-snails-drive.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': patch
+---
+
+chore: quick fix for global box-sizing override

--- a/src/emotion-cache.tsx
+++ b/src/emotion-cache.tsx
@@ -30,11 +30,6 @@ export const EmotionCache = ({
             line-height: 1.5;
             box-sizing: border-box;
           }
-          *,
-          *:before,
-          *:after {
-            box-sizing: inherit;
-          }
         `}
       />
       {children}


### PR DESCRIPTION
chore: quick fix for global box-sizing override