### PR TITLE
fix: unable to customize input

### DIFF
--- a/.changeset/smooth-goats-share.md
+++ b/.changeset/smooth-goats-share.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': patch
+---
+
+Fix unable to customize Input component and use customClassNames for Search Input and Search Input Binding widget.

--- a/documentation/configuration-reference.md
+++ b/documentation/configuration-reference.md
@@ -461,6 +461,7 @@ The Takeover Search Input widget allows users to inject Sajari search experience
 | `selector`                | `string`                                                        | `'form[action="/search"] input[name="q"]' if the preset is 'shopify'` | The CSS selector of the input being taken over.                                                             |
 | `mode`                    | `'standard'` \| `'typeahead'` \| `'suggestions'` \| `'results'` | `'results'`                                                           | The mode of the input. For details, see [Input props](https://react.docs.sajari.com/search-ui/input#props). |
 | `omittedElementSelectors` | `string` \| `string[]`                                          | `_`                                                                   | A single or a list of CSS selector of elements to be removed when the widget has mounted.                   |
+| `options`                 | `Omit<InputProps, 'retainFilters' \| 'mode'>`                   | `_`                                                                   | Options to customize Input component. See [Input props](https://react.docs.sajari.com/search-ui/**input**). |
 
 <details>
 <summary>Click to expand example</summary>
@@ -492,6 +493,7 @@ The search input widget is typically used in a global template and positioned in
 | ---------- | --------------------------------------------------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `mode`     | `'standard'` \| `'typeahead'` \| `'suggestions'` \| `'results'` | `'suggestions'`                        | The mode of the input. For details, see [Input props](https://react.docs.sajari.com/search-ui/input#props).                                                                |
 | `redirect` | `{url: string, queryParamName: string}`                         | `{url: 'search', queryParamName: 'q'}` | Options to set the redirect URL and the name of the search query param, normally, the destination is where the [Search Results Widget](#search-results-widget) is located. |
+| `options`  | `Omit<InputProps, 'retainFilters' \| 'mode'>`                   | `_`                                    | Options to customize Input component. See [Input props](https://react.docs.sajari.com/search-ui/.**input**)                                                                |
 
 <details>
 <summary>Click to expand example</summary>

--- a/src/search-input-binding.tsx
+++ b/src/search-input-binding.tsx
@@ -39,11 +39,11 @@ const Wrapper = ({
   children,
   searchContext,
   ...props
-}: Pick<SearchInputBindingProps, 'theme' | 'defaultFilter' | 'currency'> & {
+}: Pick<SearchInputBindingProps, 'theme' | 'defaultFilter' | 'currency' | 'customClassNames'> & {
   children: React.ReactNode;
   searchContext: ContextProviderValues['search'];
 }) => {
-  const { theme, defaultFilter, currency } = props;
+  const { theme, defaultFilter, currency, customClassNames } = props;
   return (
     <SearchProvider
       search={searchContext}
@@ -51,6 +51,7 @@ const Wrapper = ({
       searchOnLoad={false}
       defaultFilter={defaultFilter}
       currency={currency}
+      customClassNames={customClassNames}
     >
       {children}
     </SearchProvider>
@@ -62,10 +63,10 @@ const renderBindingInput = (
   searchContext: ContextProviderValues['search'],
   params: Omit<SearchInputBindingProps, 'selector' | 'omittedElementSelectors'>,
 ) => {
-  const { mode = 'suggestions', container, ...props } = params;
+  const { mode = 'suggestions', container, options, ...props } = params;
 
   targets.forEach((target) => {
-    const showPoweredBy = props.preset !== 'shopify';
+    const showPoweredBy = options?.showPoweredBy ?? props.preset !== 'shopify';
 
     if (target instanceof HTMLInputElement) {
       const fragment = document.createDocumentFragment();
@@ -76,6 +77,7 @@ const renderBindingInput = (
         <Wrapper searchContext={searchContext} {...props}>
           <EmotionCache cacheKey={mode} container={container}>
             <Input
+              {...options}
               portalContainer={container}
               mode={mode}
               onSelect={onSelectHandler(target)}
@@ -101,6 +103,7 @@ const renderBindingInput = (
           <Wrapper searchContext={searchContext} {...props}>
             <EmotionCache cacheKey={mode} container={container}>
               <Input
+                {...options}
                 portalContainer={container}
                 mode={mode}
                 onSelect={onSelectHandler(element)}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -128,6 +128,7 @@ export interface SearchInputBindingProps extends SearchWidgetBaseOptions {
   selector: string;
   mode: Exclude<InputMode, 'instant'>;
   omittedElementSelectors?: string | string[];
+  options?: Omit<CoreInputProps, 'mode' | 'retainFilters'>;
 }
 
 export interface SearchInputProps extends SearchWidgetBaseOptions {
@@ -137,7 +138,9 @@ export interface SearchInputProps extends SearchWidgetBaseOptions {
     queryParamName: string;
   };
   emitter?: Emitter;
-  options?: {
+  options?: Omit<CoreInputProps, 'mode' | 'retainFilters'> & {
+    // @deprecated: moved the ability to custom input props into the upper-level options
+    // keep the prop for v2 in case customers used it to customize the input but consider dropping the support for the prop in v3
     input?: InputProps;
   };
 }


### PR DESCRIPTION
A couple of fixes for  Search Input and Search Input Binding:
- [x] Fix unable to use `customClassNames` - https://sajari.atlassian.net/browse/SF-544
- [x] Enable customizing Input component via options prop
```html
<div data-widget="search-input">
  <script type="application/json">
   {
        "account": "1603163345448404241",
        "collection": "sajari-test-fashion2",
        "pipeline": "query",
        "options": {
           "showPoweredBy": false
        }
    }
  </script>
</div>
```