### PR TITLE
fix: missing shopify field mapping for input widgets

### DIFF
--- a/.changeset/plenty-forks-learn.md
+++ b/.changeset/plenty-forks-learn.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': patch
+---
+
+Fix missing Shopify field mapping for the Search Input and Search Input Binding that causes links on the dropdown of `results` mode to be unclickable.

--- a/src/search-input-binding.tsx
+++ b/src/search-input-binding.tsx
@@ -3,7 +3,7 @@ import { ContextProviderValues, Input, Pipeline, SearchProvider, Variables } fro
 import { render } from 'preact/compat';
 import { useEffect, useMemo } from 'react';
 
-import { getPresetSelector } from './defaults';
+import { getPresetSelector, shopifyFieldMapping } from './defaults';
 import { EmotionCache } from './emotion-cache';
 import { SearchInputBindingProps } from './types';
 import { getPipelineInfo } from './utils';
@@ -154,7 +154,7 @@ export default ({ selector: selectorProp, omittedElementSelectors, ...rest }: Se
       ),
       config,
       variables,
-      fields,
+      fields: rest.preset === 'shopify' ? { ...shopifyFieldMapping, ...fields } : fields,
     };
   }, []);
 

--- a/src/search-input.tsx
+++ b/src/search-input.tsx
@@ -3,6 +3,7 @@ import { Input, Pipeline, SearchProvider, Variables } from '@sajari/react-search
 import { useRef } from 'preact/hooks';
 import { useMemo } from 'react';
 
+import { shopifyFieldMapping } from './defaults';
 import PubSubContextProvider from './pubsub/context';
 import { SearchInputProps } from './types';
 import { getPipelineInfo } from './utils';
@@ -48,7 +49,7 @@ export default (defaultProps: SearchInputProps) => {
       ),
       config,
       variables,
-      fields,
+      fields: preset === 'shopify' ? { ...shopifyFieldMapping, ...fields } : fields,
     };
   }, []);
 


### PR DESCRIPTION
Fix missing Shopify field mapping for the Search Input and Search Input Binding that causes links on the dropdown of `results` mode to be unclickable.