### PR TITLE
fix: mobile view loop

### DIFF
--- a/.changeset/funny-dolls-obey.md
+++ b/.changeset/funny-dolls-obey.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': patch
+---
+
+Fix the mobile view switching to non-mobile view loop

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useDebounce';
 export * from './useQueryParam';
 export * from './useSearchProviderProps';
+export * from './useWindowSize';

--- a/src/hooks/useWindowSize/index.ts
+++ b/src/hooks/useWindowSize/index.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+export function useWindowSize() {
+  // Initialize state with undefined width/height so server and client renders match
+  // Learn more here: https://joshwcomeau.com/react/the-perils-of-rehydration/
+  const [windowSize, setWindowSize] = useState<{ width?: number; height?: number }>({});
+
+  useEffect(() => {
+    // Handler to call on window resize
+    function handleResize() {
+      // Set window width/height to state
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    }
+    // Add event listener
+    window.addEventListener('resize', handleResize);
+    // Call handler right away so state gets updated with initial window size
+    handleResize();
+    // Remove event listener on cleanup
+    return () => window.removeEventListener('resize', handleResize);
+  }, []); // Empty array ensures that effect is only run on mount
+  return windowSize;
+}


### PR DESCRIPTION
## How
This bug was caused by the `ResizeObserver` setting width of an element while the parent of that element also changes width based on its children but in reverse order causing this loop, see video for more detail

https://streamable.com/kzzm5o

In the video whenever the observed element (1) is under 640 width (meaning mobile) the modal changes the overlay to be fullwidth which causes (1) to be also fullwidth and in turn makes its width larger than 640 (non-mobile) and that update the width resulting in a loop.

## Solution
Remove `ResizeObserver`, use a hook that watches the screen size instead of an element's size