### PR TITLE
fix: closing overlay modal with escape key causes body scroll to lock

### DIFF
--- a/.changeset/stale-worms-play.md
+++ b/.changeset/stale-worms-play.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': patch
+---
+
+Prevent body scroll from locking when overlay modal is closed with the escape key.

--- a/src/interface/OverlayInterface.tsx
+++ b/src/interface/OverlayInterface.tsx
@@ -237,7 +237,7 @@ const OverlayInterface = () => {
                 css={[tw`overflow-y-auto`, isMobileGrid ? tw`pt-2 sm:pt-6 pr-2 sm:pr-6` : tw`pt-6 pr-6`]}
                 ref={(node) => {
                   if (!node) return;
-                  disableBodyScroll(node);
+                  if (open) disableBodyScroll(node);
                 }}
               >
                 <div css={tw`mb-6`}>


### PR DESCRIPTION
After typing a few characters into the overlay modal input and then pressing the `esc` key to close the modal, the body of the page becomes locked and cannot be scrolled. 

Refer to issue: https://sajari.atlassian.net/browse/SF-657