### PR TITLE
fix: remove body-scroll-lock to avoid overlay esc to lock body scroll

### DIFF
--- a/.changeset/calm-colts-float.md
+++ b/.changeset/calm-colts-float.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': patch
+---
+
+Remove the dependency on body-scroll-lock methods to fix the issue when the body scroll is locked if closing the overlay modal with the escape key.

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "@sajari/react-hooks": "^3.6.1",
     "@sajari/react-sdk-utils": "^1.6.3",
     "@sajari/react-search-ui": "^4.8.2",
-    "body-scroll-lock": "^3.1.5",
     "lodash-es": "^4.17.21",
     "mitt": "^2.1.0",
     "preact": "^10.5.12",

--- a/src/interface/Options/index.tsx
+++ b/src/interface/Options/index.tsx
@@ -18,9 +18,6 @@ import {
   Summary as CoreSummary,
   ViewType,
 } from '@sajari/react-search-ui';
-// TODO: ideally this should be a generic solution in the Modal component
-// making a note here so we (Thanh) can revisit the issue
-import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
 import React, { useEffect, useState } from 'react';
 import tw, { styled } from 'twin.macro';
 
@@ -115,7 +112,6 @@ export default ({ showToggleFilter = true, isMobile = false, onScrollTop, mode =
   const nonTabsFilters = filters?.filter((props) => props.type !== 'tabs') || [];
   const [filterList, setActiveFilterList] = useState(filters.map(() => false));
   const count = filterList.filter(Boolean).length;
-  let refScrollBox: HTMLDivElement | null;
 
   const setActiveFilter = (index: number, value: boolean) => {
     const newValues = [...filterList];
@@ -140,20 +136,6 @@ export default ({ showToggleFilter = true, isMobile = false, onScrollTop, mode =
       clearTimeout(timeout);
     };
   }, [open]);
-
-  useEffect(() => {
-    if (refScrollBox && !open) {
-      enableBodyScroll(refScrollBox);
-    }
-  }, [open]);
-
-  useEffect(() => {
-    return () => {
-      if (refScrollBox) {
-        enableBodyScroll(refScrollBox);
-      }
-    };
-  }, []);
 
   const showSorting = options.sorting?.options && options.sorting.options.length;
   const showViewType = options.showViewType ?? true;
@@ -207,14 +189,7 @@ export default ({ showToggleFilter = true, isMobile = false, onScrollTop, mode =
           <ModalCloseButton />
         </ModalHeader>
 
-        <ModalBody
-          css={[tw`pt-2`, 'font-size: 16px;']}
-          ref={(node) => {
-            if (!node) return;
-            refScrollBox = node;
-            disableBodyScroll(node);
-          }}
-        >
+        <ModalBody css={[tw`pt-2`, 'font-size: 16px;']}>
           <div css={[tw`space-y-6 divide-y`, count === 0 ? tw`pb-0` : tw`pb-16`]}>
             {showSorting && <Sorting type="list" size="sm" inline={md} options={options.sorting?.options} />}
             {results &&

--- a/src/interface/OverlayInterface.tsx
+++ b/src/interface/OverlayInterface.tsx
@@ -2,9 +2,6 @@ import { Modal, ModalCloseButton } from '@sajari/react-components';
 import { useQuery, useSearchContext, useSorting } from '@sajari/react-hooks';
 import { isArray, isNumber } from '@sajari/react-sdk-utils';
 import { Filter, Input, Pagination, Results, useSearchUIContext } from '@sajari/react-search-ui';
-// TODO: ideally this should be a generic solution in the Modal component
-// making a note here so we (Thanh) can revisit the issue
-import { clearAllBodyScrollLocks, disableBodyScroll } from 'body-scroll-lock';
 import { memo } from 'preact/compat';
 import { useCallback, useEffect, useState } from 'preact/hooks';
 import tw from 'twin.macro';
@@ -126,18 +123,6 @@ const OverlayInterface = () => {
   }, [isMobile, open]);
 
   useEffect(() => {
-    if (!open) {
-      clearAllBodyScrollLocks();
-    }
-  }, [open]);
-
-  useEffect(() => {
-    return () => {
-      clearAllBodyScrollLocks();
-    };
-  }, []);
-
-  useEffect(() => {
     if (isNumber(width)) {
       setWidth(width);
     }
@@ -236,10 +221,6 @@ const OverlayInterface = () => {
                 <div
                   id={containerId}
                   css={[tw`overflow-y-auto`, isMobileGrid ? tw`pt-2 sm:pt-6 pr-2 sm:pr-6` : tw`pt-6 pr-6`]}
-                  ref={(node) => {
-                    if (!node) return;
-                    disableBodyScroll(node);
-                  }}
                 >
                   <div css={tw`mb-6`}>
                     <Results


### PR DESCRIPTION
Remove the dependency on `body-scroll-lock` methods to fix the issue when the body scroll is locked if closing the overlay modal with the escape key. 

Previously, the code was to handle overflow conflict between the overlay modal and the filter modal but after removing the code, I cannot reproduce the issue so it could be safe to remove.
