### PR TITLE
test: disable unstable overlay e2e test

### DIFF
--- a/cypress/integration/overlay.test.ts
+++ b/cypress/integration/overlay.test.ts
@@ -1,21 +1,25 @@
 describe('Search Overlay', async () => {
-  it('Should open modal and run search successfully', () => {
-    cy.visit('/');
-    cy.get('#toolbar button').click();
-    cy.get('[role="listbox"] [role="option"]:last-child').click();
+  // TODO (thanh): this test is unstable in CI as it occasionally
+  // causes detached DOM element issue. Temporarily disable the test
+  // for further investigation
 
-    cy.get('#button').click({ force: true });
+  // it('Should open modal and run search successfully', () => {
+  //   cy.visit('/');
+  //   cy.get('#toolbar button').click();
+  //   cy.get('[role="listbox"] [role="option"]:last-child').click();
 
-    // Wait for modal to appear. Without the line, Github CI normally fails
-    // to detect the element and is causing the test to fail
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(1000);
+  //   cy.get('#button').click({ force: true });
 
-    cy.get('[type="search"]').type('shirt');
-    cy.get('[data-testid="options-bar"] strong').should('have.text', 'shirt');
-    cy.get('button[aria-label="Close"]').click();
-    cy.get('[data-testid="modal"]').should('not.exist');
-  });
+  //   // Wait for modal to appear. Without the line, Github CI normally fails
+  //   // to detect the element and is causing the test to fail
+  //   // eslint-disable-next-line cypress/no-unnecessary-waiting
+  //   cy.wait(1000);
+
+  //   cy.get('[type="search"]').type('shirt');
+  //   cy.get('[data-testid="options-bar"] strong').should('have.text', 'shirt');
+  //   cy.get('button[aria-label="Close"]').click();
+  //   cy.get('[data-testid="modal"]').should('not.exist');
+  // });
 
   it('Should use the value from "inputSelector" element to search', () => {
     cy.visit('/');


### PR DESCRIPTION
Temporarily disable the unstable test to avoid failing CI in other PRs while I'm investigating the solution in https://github.com/sajari/search-widgets/pull/261