### PR TITLE
test: add test cases for takeover input

### DIFF
--- a/cypress/integration/takeover-input.test.ts
+++ b/cypress/integration/takeover-input.test.ts
@@ -1,19 +1,64 @@
-describe('Search Takeover Input', async () => {
-  it('Should redirect after running a search', () => {
-    cy.visit('/');
-    cy.get('#toolbar button').click();
-    cy.get('[role="listbox"] [role="option"]:nth-child(2)').click();
+const defaultSearchInputBindingConfig: any = {
+  account: '1603163345448404241',
+  collection: 'sajari-test-fashion2',
+  pipeline: 'query',
+  preset: 'shopify',
+  selector: "input[name='q']",
+  mode: 'suggestions',
+  redirect: { url: 'search', queryParamName: 'q' },
+};
 
+const visitTakeoverInput = (config = defaultSearchInputBindingConfig) => {
+  cy.setLocalStorage('code-content-search-input-binding', JSON.stringify(config));
+  cy.setLocalStorage('active-widget', 'search-input-binding');
+  cy.visit('/');
+};
+
+describe('Search Takeover Input', async () => {
+  beforeEach(() => {
+    cy.viewport(1440, 720);
+  });
+
+  it('Should redirect after running a search', () => {
+    visitTakeoverInput();
     cy.get('form input').first().type('shirt', { force: true, delay: 1000 });
     cy.get('form').first().submit();
+
     cy.url().should('include', '/search?q=shirt');
   });
 
-  it('Should use the value from q param as the default value for the input', () => {
-    cy.visit('/?q=jacket');
-    cy.get('#toolbar button').click();
-    cy.get('[role="listbox"] [role="option"]:nth-child(2)').click();
+  it('Should show the dropdown', () => {
+    visitTakeoverInput();
+    cy.get('form input').first().type('dress', { force: true, delay: 500 });
 
-    cy.get('form input').first().should('have.value', 'jacket');
+    cy.get('ul li').contains('dress').should('be.visible');
+  });
+
+  it('Should mount the input to a different element base on the selector', () => {
+    visitTakeoverInput({
+      ...defaultSearchInputBindingConfig,
+      selector: '#js-search-input',
+    });
+
+    cy.get('form input').first().type('dress', { force: true, delay: 500 });
+
+    cy.get('ul[role="listbox"]').each((element) => {
+      cy.wrap(element).should('not.be.visible');
+    });
+
+    cy.get('#js-search-input input').first().type('dress', { force: true, delay: 500 });
+
+    cy.get('ul li').contains('dress').should('be.visible');
+  });
+
+  it('Should remove elements according to the `omittedElementSelectors` prop', () => {
+    visitTakeoverInput({
+      ...defaultSearchInputBindingConfig,
+      omittedElementSelectors: '#js-search-input',
+    });
+
+    visitTakeoverInput();
+
+    cy.get('#js-search-input').should('not.exist');
   });
 });

--- a/cypress/integration/takeover-input.test.ts
+++ b/cypress/integration/takeover-input.test.ts
@@ -1,4 +1,4 @@
-const defaultSearchInputBindingConfig: any = {
+const defaultConfig: any = {
   account: '1603163345448404241',
   collection: 'sajari-test-fashion2',
   pipeline: 'query',
@@ -8,7 +8,7 @@ const defaultSearchInputBindingConfig: any = {
   redirect: { url: 'search', queryParamName: 'q' },
 };
 
-const visitTakeoverInput = (config = defaultSearchInputBindingConfig) => {
+const visitTakeoverInput = (config = defaultConfig) => {
   cy.setLocalStorage('code-content-search-input-binding', JSON.stringify(config));
   cy.setLocalStorage('active-widget', 'search-input-binding');
   cy.visit('/');
@@ -36,7 +36,7 @@ describe('Search Takeover Input', async () => {
 
   it('Should mount the input to a different element base on the selector', () => {
     visitTakeoverInput({
-      ...defaultSearchInputBindingConfig,
+      ...defaultConfig,
       selector: '#js-search-input',
     });
 
@@ -53,12 +53,18 @@ describe('Search Takeover Input', async () => {
 
   it('Should remove elements according to the `omittedElementSelectors` prop', () => {
     visitTakeoverInput({
-      ...defaultSearchInputBindingConfig,
+      ...defaultConfig,
       omittedElementSelectors: '#js-search-input',
     });
 
-    visitTakeoverInput();
-
     cy.get('#js-search-input').should('not.exist');
+  });
+
+  it('Should show dropdown on results mode', () => {
+    cy.intercept({ url: '**/Search', method: 'POST' });
+    visitTakeoverInput({ ...defaultConfig, mode: 'results' });
+
+    cy.get('form input').first().type('shirt', { force: true, delay: 500 });
+    cy.get('h6').contains('Results').should('be.visible');
   });
 });


### PR DESCRIPTION
This PR adds the following test cases:
- [x] Test that the dropdown actually shows
- [x] Test against different selectors
- [x] Test the omittedElementSelectors prop
- [ ] ~~Test the `typeahead` mode~~ removed since we only render the Dropdown component so `typeahead` mode is not relevant - [source](https://github.com/sajari/sdk-react/blob/master/packages/components/src/Combobox/index.tsx#L344)
- [x] Test the `results` mode
---
SF-800