### PR TITLE
ci: separate workflow of unit and e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,4 +1,4 @@
-name: Run test
+name: Run e2e tests
 
 on:
   pull_request:
@@ -16,10 +16,6 @@ jobs:
         uses: styfle/cancel-workflow-action@0.8.0
         with:
           access_token: ${{ github.token }}
-      - name: Jest run
-        run: |
-          yarn
-          yarn test:ci
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,22 @@
+name: Run unit tests
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
+      - name: Jest run
+        run: |
+          yarn
+          yarn test:ci


### PR DESCRIPTION
Separate the workflow of unit tests and e2e tests to reduce the waiting time for CI.