### PR TITLE
fix: remap id

### DIFF
--- a/.changeset/moody-trainers-sell.md
+++ b/.changeset/moody-trainers-sell.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': patch
+---
+
+Remap the id property if using shopify preset

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -30,6 +30,7 @@ const getVariantImages = (values: ShopifySchema) => {
 };
 
 export const shopifyFieldMapping: FieldDictionary = {
+  id: 'id',
   // eslint-disable-next-line no-template-curly-in-string
   url: '/products/${handle}',
   subtitle: 'vendor',


### PR DESCRIPTION
Remap the id property if using the shopify preset to keep it consistent between tracking objects