### PR TITLE
fix: add assistive labels to toggle filter button

### DIFF
--- a/.changeset/ten-chefs-try.md
+++ b/.changeset/ten-chefs-try.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': patch
+---
+
+Add assistive labels for toggle filter button

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@sajari/react-components": "^1.14.4",
     "@sajari/react-hooks": "^3.12.0",
     "@sajari/react-sdk-utils": "^1.6.4",
-    "@sajari/react-search-ui": "^4.14.2",
+    "@sajari/react-search-ui": "^4.15.0",
     "@types/react-dom": "^17.0.9",
     "body-scroll-lock": "^3.1.5",
     "lodash-es": "^4.17.21",

--- a/src/interface/Options/ToggleFilters.tsx
+++ b/src/interface/Options/ToggleFilters.tsx
@@ -9,6 +9,7 @@ export default () => {
   const toggleFilters = () => setFiltersShown(!filtersShown);
   const { t } = useTranslation('filter');
   const label = filtersShown ? t('hide') : t('show');
+  const screenReaderLabel = t('toggleFilters');
 
   return (
     <Button
@@ -22,7 +23,7 @@ export default () => {
     >
       {label}
       <Label css={tw`sr-only`} htmlFor="toggle-filters">
-        Toggle Filters
+        {screenReaderLabel}
       </Label>
     </Button>
   );

--- a/src/interface/Options/ToggleFilters.tsx
+++ b/src/interface/Options/ToggleFilters.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@sajari/react-components';
+import { Button, Label } from '@sajari/react-components';
 import { useTranslation } from 'react-i18next';
 import tw from 'twin.macro';
 
@@ -8,18 +8,22 @@ export default () => {
   const { filtersShown, setFiltersShown } = useInterfaceContext();
   const toggleFilters = () => setFiltersShown(!filtersShown);
   const { t } = useTranslation('filter');
+  const label = filtersShown ? t('hide') : t('show');
 
   return (
     <Button
-      role="checkbox"
+      role="switch"
       aria-checked={filtersShown}
-      aria-label="Toggle Filters"
       type="button"
       size="sm"
       onClick={toggleFilters}
       css={tw`whitespace-nowrap m-0`}
+      id="toggle-filters"
     >
-      {filtersShown ? t('hide') : t('show')}
+      {label}
+      <Label css={tw`sr-only`} htmlFor="toggle-filters">
+        Toggle Filters
+      </Label>
     </Button>
   );
 };

--- a/src/interface/Options/ToggleFilters.tsx
+++ b/src/interface/Options/ToggleFilters.tsx
@@ -10,7 +10,15 @@ export default () => {
   const { t } = useTranslation('filter');
 
   return (
-    <Button type="button" size="sm" onClick={toggleFilters} css={tw`whitespace-nowrap m-0`}>
+    <Button
+      role="checkbox"
+      aria-checked={filtersShown}
+      aria-label="Toggle Filters"
+      type="button"
+      size="sm"
+      onClick={toggleFilters}
+      css={tw`whitespace-nowrap m-0`}
+    >
       {filtersShown ? t('hide') : t('show')}
     </Button>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3287,10 +3287,10 @@
     tailwindcss-truncate-multiline "^1.0.3"
     twin.macro "^1.12.1"
 
-"@sajari/react-search-ui@^4.14.2":
-  version "4.14.2"
-  resolved "https://registry.yarnpkg.com/@sajari/react-search-ui/-/react-search-ui-4.14.2.tgz#09c23624cb27633baf2771e39cc13dc6661c9398"
-  integrity sha512-e2IINIr4xDEDFGOJEIdDHpgCzM62caqAxg2uoOx2MenX7r9FQVEEsz0inDTl4ikUMvjDW/lXzD7h2YuyqTF7ig==
+"@sajari/react-search-ui@^4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@sajari/react-search-ui/-/react-search-ui-4.15.0.tgz#200bf3be2d66b1787936919fb40b87ea941de61d"
+  integrity sha512-yMOtajI97cvee+MDhAeQSQ1DBCcIq3zM54gg48x1TvIGVztyifFDD8l4pUjTbpOBAiFfLyizuLyWOdgK4qZH2w==
   dependencies:
     "@react-aria/utils" "3.5.0"
     "@sajari/react-components" "^1.14.4"


### PR DESCRIPTION
## Problem
The state of the button was not announced by the screen reader

## Solution
Add the assistive attributes of that like of a switch for the toggle filter button, where `checked=true` is equivalent to the filters being shown and `checked=false` is equivalent to the filters hidden

-----
SF-528