### PR TITLE
test: add network count tests

### DIFF
--- a/cypress/integration/results.test.ts
+++ b/cypress/integration/results.test.ts
@@ -19,6 +19,36 @@ describe('Search Results', async () => {
   });
 });
 
+describe('Network count', async () => {
+  it('Should call /Search API only once after init app', () => {
+    let count = 0;
+    cy.intercept('POST', '**/Search', { body: {} });
+    cy.intercept('POST', '**/Search', () => {
+      count += 1;
+    }).as('search');
+
+    visitSearchResults();
+
+    cy.wait('@search').then(() => {
+      expect(count).to.equal(1);
+    });
+  });
+
+  it('Should call /Search API only once if URL params is available', () => {
+    let count = 0;
+    cy.intercept('POST', '**/Search', { body: {} });
+    cy.intercept('POST', '**/Search', () => {
+      count += 1;
+    }).as('search');
+
+    visitSearchResults('/?q=test&show=25&sort=max_price&vendor=Hannes+Roether');
+
+    cy.wait('@search').then(() => {
+      expect(count).to.equal(1);
+    });
+  });
+});
+
 describe('Pagination', async () => {
   beforeEach(() => {
     cy.viewport(1440, 720);


### PR DESCRIPTION
This PR is to ensure the search request is only called once when either the URL has params or not as I noticed a change in the React SDK or in the codebase could accidentally trigger the request to call twice in https://github.com/sajari/search-widgets/pull/297.

![image](https://user-images.githubusercontent.com/12707960/168851882-4994ea1e-829e-4d01-bdef-45afcf0b7292.png)
