### PR TITLE
chore: fix deployment tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    types:
+      - closed
 
 jobs:
   release:
@@ -27,6 +30,7 @@ jobs:
       - name: Create Release Pull Request
         id: changesets
         uses: changesets/action@v1
+        if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.title == 'Release latest to Production'
         with:
           # This will only run when it's a release commit by the changeset bot
           publish: yarn deploy:full
@@ -38,7 +42,7 @@ jobs:
 
       - id: deploytostaging
         name: Deploy to Staging
-        if: steps.changesets.outputs.published == 'false'
+        if: github.event_name == 'push' || steps.changesets.outputs.published == 'false'
         run: yarn deploy:staging
         env:
           GOOGLE_CLIENT_EMAIL: ${{ secrets.GOOGLE_CLIENT_EMAIL }}


### PR DESCRIPTION
I believe that this should be sufficient to ensure that:
* deploys to prod only occur as a result of a changeset bot PR landing
* deploys to staging occur on any push to master except when it's a changeset bot PR landing

It also seems (I could be wrong) that any random push to master at the moment that doesn't contain a changeset will be pushed live to the CDN _overwriting what is currently there for that version_ before creating a new tag afterwards.