### PR TITLE
test: add test cases for default value setting

### DIFF
--- a/cypress/integration/results.test.ts
+++ b/cypress/integration/results.test.ts
@@ -247,7 +247,7 @@ describe('Custom result template', async () => {
 });
 
 describe('Custom default value of variables', async () => {
-  it('Custom resultsPerPage should work', () => {
+  it.only('Custom resultsPerPage should work', () => {
     const config: any = {
       account: '1603163345448404241',
       collection: 'sajari-test-fashion2',
@@ -269,6 +269,14 @@ describe('Custom default value of variables', async () => {
       });
 
     cy.url().should('include', 'show=15');
+
+    cy.get('[data-testid="results-per-page"]')
+      .click()
+      .within(() => {
+        cy.get('li:nth-child(2)').click();
+      });
+
+    cy.url().should('not.include', 'show');
   });
 });
 

--- a/cypress/integration/results.test.ts
+++ b/cypress/integration/results.test.ts
@@ -247,7 +247,7 @@ describe('Custom result template', async () => {
 });
 
 describe('Custom default value of variables', async () => {
-  it.only('Custom resultsPerPage should work', () => {
+  it('Custom resultsPerPage should work', () => {
     const config: any = {
       account: '1603163345448404241',
       collection: 'sajari-test-fashion2',
@@ -280,7 +280,7 @@ describe('Custom default value of variables', async () => {
   });
 });
 
-describe.only('Custom urlParams', async () => {
+describe('Custom urlParams', async () => {
   const config: any = {
     account: '1603163345448404241',
     collection: 'sajari-test-fashion2',

--- a/cypress/integration/results.test.ts
+++ b/cypress/integration/results.test.ts
@@ -245,3 +245,61 @@ describe('Custom result template', async () => {
       });
   });
 });
+
+describe('Custom default value of variables', async () => {
+  it('Custom resultsPerPage should work', () => {
+    const config: any = {
+      account: '1603163345448404241',
+      collection: 'sajari-test-fashion2',
+      pipeline: 'query',
+      preset: 'shopify',
+      variables: {
+        resultsPerPage: 25,
+      },
+    };
+    localStorage.setItem('code-content-search-results', JSON.stringify(config));
+    cy.intercept('POST', '**/Search', { fixture: 'promotion' }).as('search');
+    visitSearchResults();
+    cy.url().should('not.include', 'show');
+
+    cy.get('[data-testid="results-per-page"]')
+      .click()
+      .within(() => {
+        cy.get('li:nth-child(1)').click();
+      });
+
+    cy.url().should('include', 'show=15');
+  });
+});
+
+describe.only('Custom urlParams', async () => {
+  const config: any = {
+    account: '1603163345448404241',
+    collection: 'sajari-test-fashion2',
+    pipeline: 'query',
+    preset: 'shopify',
+    options: {
+      urlParams: {
+        q: 'query',
+      },
+    },
+  };
+
+  it('Should change default value of q param', () => {
+    localStorage.setItem('code-content-search-results', JSON.stringify(config));
+    cy.intercept('POST', '**/Search', { fixture: 'promotion' }).as('search');
+    visitSearchResults();
+
+    cy.get('input[type="search"]').first().type('shirt');
+    cy.get('input[type="search"]').first().should('have.value', 'shirt');
+    cy.url().should('include', '?query=shirt');
+  });
+
+  it('Should sync state from URL param', () => {
+    localStorage.setItem('code-content-search-results', JSON.stringify(config));
+    cy.intercept('POST', '**/Search', { fixture: 'promotion' }).as('search');
+    visitSearchResults('/?query=test');
+
+    cy.get('input[type="search"]').first().should('have.value', 'test');
+  });
+});


### PR DESCRIPTION
Add tests to cover the incident due to URL state sync refactor:

- [x] Modification of `variables.resultsPerPage` should work correctly
- [x] Modification of `urlParams.q` should work correctly