### PR TITLE
test: add test to check URL sync should not be in overlay mode

### DIFF
--- a/cypress/integration/overlay.test.ts
+++ b/cypress/integration/overlay.test.ts
@@ -50,4 +50,12 @@ describe('Search Overlay', () => {
     cy.get('[data-testid="overlay-results"]').find('a').first().click();
     cy.url().should('include', '/products/ultime-shirt-dress-2');
   });
+
+  it('Should not inject URL param after changing UI state', () => {
+    cy.get('#button').click();
+    cy.get('[data-testid="modal"]').find('[type="search"]').should('be.visible').type('jacket');
+    // eslint-disable-next-line
+    cy.wait(500);
+    cy.url().should('not.include', 'q=jacket');
+  });
 });

--- a/cypress/integration/overlay.test.ts
+++ b/cypress/integration/overlay.test.ts
@@ -54,6 +54,7 @@ describe('Search Overlay', () => {
   it('Should not inject URL param after changing UI state', () => {
     cy.get('#button').click();
     cy.get('[data-testid="modal"]').find('[type="search"]').should('be.visible').type('jacket');
+    // Wait a bit for the URL updated due to debouncing effect
     // eslint-disable-next-line
     cy.wait(500);
     cy.url().should('not.include', 'q=jacket');


### PR DESCRIPTION
Add a test to cover the issue in https://github.com/sajari/search-widgets/pull/315 where the URL state sync should not be enabled in the overlay mode.