### PR TITLE
fix: set default viewType ability was removed

### DIFF
--- a/.changeset/moody-hornets-work.md
+++ b/.changeset/moody-hornets-work.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': patch
+---
+
+Fix the issue when setting `options.results.viewType` doesn't work. It was because the code to set the default viewType was unwantedly removed during the refactor Sync State URL

--- a/cypress/integration/results.test.ts
+++ b/cypress/integration/results.test.ts
@@ -149,6 +149,24 @@ describe('Result items display', async () => {
     cy.get('button[aria-label="List"]').should('not.have.css', 'background-color', 'rgb(255, 255, 255)');
     cy.get('article[data-testid="result-item"]').parent().should('have.css', 'display', 'flex');
   });
+
+  it.only('Should be able to change default viewType from grid to list', () => {
+    const config: any = {
+      account: '1603163345448404241',
+      collection: 'sajari-test-fashion2',
+      pipeline: 'query',
+      preset: 'shopify',
+      options: {
+        results: {
+          viewType: 'list',
+        },
+      },
+    };
+    localStorage.setItem('code-content-search-results', JSON.stringify(config));
+    visitSearchResults('/');
+    cy.get('button[aria-label="Grid"]').should('have.attr', 'aria-checked', 'false');
+    cy.get('button[aria-label="List"]').should('have.attr', 'aria-checked', 'true');
+  });
 });
 
 describe('Promotions', async () => {

--- a/src/hooks/useSearchProviderProps/index.ts
+++ b/src/hooks/useSearchProviderProps/index.ts
@@ -1,5 +1,5 @@
 import { isNullOrUndefined } from '@sajari/react-sdk-utils';
-import { FilterBuilder, Pipeline, RangeFilterBuilder, Variables } from '@sajari/react-search-ui';
+import { FilterBuilder, Pipeline, RangeFilterBuilder, ResultViewType, Variables } from '@sajari/react-search-ui';
 import { useMemo } from 'react';
 
 import { mergeProps } from '../../defaults';
@@ -53,6 +53,7 @@ export function useSearchProviderProps(props: SearchResultsProps) {
   }, []);
 
   const variables = useMemo(() => new Variables({ ...variablesProp }), []);
+  const viewType: ResultViewType = options.results?.viewType ?? 'grid';
 
   const filters = useMemo(() => {
     return filtersProp.map((filter) => {
@@ -102,5 +103,6 @@ export function useSearchProviderProps(props: SearchResultsProps) {
     disableDefaultStyles,
     importantStyles,
     currency,
+    viewType,
   };
 }

--- a/src/search-results.tsx
+++ b/src/search-results.tsx
@@ -24,6 +24,7 @@ export default (defaultProps: SearchResultsProps) => {
     disableDefaultStyles,
     importantStyles,
     currency,
+    viewType,
   } = useSearchProviderProps(state);
   const { syncURL = 'push', mode, urlParams } = context.options as SearchResultsOptions<'standard'>;
   const emitterContext = useMemo(() => ({ emitter }), [emitter]);
@@ -57,6 +58,7 @@ export default (defaultProps: SearchResultsProps) => {
       importantStyles={importantStyles}
       currency={currency}
       downshiftEnvironment={downshiftEnvironment}
+      viewType={viewType}
       syncURLState={
         syncURL !== 'none' && mode === 'standard'
           ? { replace: syncURL === 'replace', paramKeys: { q: urlParams?.q ?? 'q' } }


### PR DESCRIPTION
Fix the issue when setting `options.results.viewType` doesn't work. It was because the code to set the default `viewType` was unwantedly removed during the refactor Sync State URL - https://github.com/sajari/search-widgets/pull/297/files#diff-9d243bee563af817d97236bac63fdcf087815a7ad1b58ef5fb36ec407c8179f3L57