### PR TITLE
feat: make redirects via the search input widget case-insensitive

### DIFF
--- a/.changeset/grumpy-cats-wink.md
+++ b/.changeset/grumpy-cats-wink.md
@@ -1,0 +1,7 @@
+---
+'@sajari/search-widgets': major
+---
+
+feat: make redirects via the search input widget case-insensitive
+
+Note: This update includes a breaking change to the way redirects work in the Search Input and Takeover Search Input widgets. The components no longer support case-sensitive redirects.

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@sajari/react-components": "^2.1.0",
     "@sajari/react-hooks": "^4.0.1",
     "@sajari/react-sdk-utils": "^2.0.0",
-    "@sajari/react-search-ui": "^5.0.2",
+    "@sajari/react-search-ui": "^6.0.0",
     "@types/react-dom": "^17.0.9",
     "body-scroll-lock": "^3.1.5",
     "lodash-es": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3553,9 +3553,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sajari/react-search-ui@npm:^5.0.2":
-  version: 5.0.2
-  resolution: "@sajari/react-search-ui@npm:5.0.2"
+"@sajari/react-search-ui@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@sajari/react-search-ui@npm:6.0.0"
   dependencies:
     "@react-aria/live-announcer": ^3.1.1
     "@react-aria/utils": 3.5.0
@@ -3571,7 +3571,7 @@ __metadata:
   peerDependencies:
     react: ">=17"
     react-dom: ">=17"
-  checksum: 27e87d7ba11c29887a98384bd7385aaf20fb9ffc55fb754889c1793e2ac85fe69ac316533e355d4ab1d1248e6837064a4780c7c06e7d3ca440b20fe0238519b7
+  checksum: ad07e9a5774b77e8796c20134e8948deb8041b963acad0d04dfb3dc9bb8b66114e04104acc0406b840cd4a9c312051fb1bd103418c384c32064ea74dee4ff793
   languageName: node
   linkType: hard
 
@@ -3605,7 +3605,7 @@ __metadata:
     "@sajari/react-components": ^2.1.0
     "@sajari/react-hooks": ^4.0.1
     "@sajari/react-sdk-utils": ^2.0.0
-    "@sajari/react-search-ui": ^5.0.2
+    "@sajari/react-search-ui": ^6.0.0
     "@testing-library/jest-dom": ^5.16.2
     "@testing-library/react": ^12.1.3
     "@types/body-scroll-lock": ^2.6.2


### PR DESCRIPTION
Bump `@sajari/react-search-ui` dependency to `v6.0.0` to adopt the [changes](https://github.com/sajari/sdk-react/pull/879) made to redirects in the `Input` component.

[DAU-249](https://algolia.atlassian.net/browse/DAU-249)