### PR TITLE
feat: add `disableRedirectOnResultSelect` prop to takeover search input widget

### DIFF
--- a/.changeset/pink-elephants-jam.md
+++ b/.changeset/pink-elephants-jam.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': minor
+---
+
+feat: add disableRedirectOnResultSelect prop to search input binding widget to provide the option to enable the default results mode onSelect behaviour when a redirect is provided

--- a/src/search-input-binding.tsx
+++ b/src/search-input-binding.tsx
@@ -109,7 +109,11 @@ const renderBindingInput = (
               minimumCharacters={minimumCharacters}
               portalContainer={container}
               mode={mode}
-              onSelect={disableRedirectOnResultSelect ? undefined : onSelectHandler(target, { mode, redirect })}
+              onSelect={
+                disableRedirectOnResultSelect && mode === 'results'
+                  ? undefined
+                  : onSelectHandler(target, { mode, redirect })
+              }
               inputElement={{ current: target }}
               showPoweredBy={showPoweredBy}
             />
@@ -136,7 +140,11 @@ const renderBindingInput = (
                 minimumCharacters={minimumCharacters}
                 portalContainer={container}
                 mode={mode}
-                onSelect={disableRedirectOnResultSelect ? undefined : onSelectHandler(element, { mode, redirect })}
+                onSelect={
+                  disableRedirectOnResultSelect && mode === 'results'
+                    ? undefined
+                    : onSelectHandler(element, { mode, redirect })
+                }
                 inputElement={{ current: element }}
                 showPoweredBy={showPoweredBy}
               />

--- a/src/search-input-binding.tsx
+++ b/src/search-input-binding.tsx
@@ -84,7 +84,7 @@ const renderBindingInput = (
   searchContext: ContextProviderValues['search'],
   params: Omit<SearchInputBindingProps, 'selector' | 'omittedElementSelectors'>,
 ) => {
-  const { mode = 'suggestions', container, options, ...props } = params;
+  const { mode = 'suggestions', container, options, disableRedirectOnResultSelect, ...props } = params;
 
   const redirect = {
     url: props.preset === 'shopify' ? '/search' : '', // Shopify always use /search for search results page
@@ -109,7 +109,7 @@ const renderBindingInput = (
               minimumCharacters={minimumCharacters}
               portalContainer={container}
               mode={mode}
-              onSelect={onSelectHandler(target, { mode, redirect })}
+              onSelect={disableRedirectOnResultSelect ? undefined : onSelectHandler(target, { mode, redirect })}
               inputElement={{ current: target }}
               showPoweredBy={showPoweredBy}
             />
@@ -136,7 +136,7 @@ const renderBindingInput = (
                 minimumCharacters={minimumCharacters}
                 portalContainer={container}
                 mode={mode}
-                onSelect={onSelectHandler(element, { mode, redirect })}
+                onSelect={disableRedirectOnResultSelect ? undefined : onSelectHandler(element, { mode, redirect })}
                 inputElement={{ current: element }}
                 showPoweredBy={showPoweredBy}
               />

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -155,6 +155,11 @@ export interface SearchInputBindingProps extends SearchWidgetBaseOptions, Pick<S
       q: string;
     };
   };
+  // Set `disableRedirectOnResultSelect` to true if `mode` is set to `results`,
+  // `redirect` has been provided, and you want to preserve the default dropdown
+  // result onSelect behaviour, rather than being redirected as specified in the
+  // `redirect` prop.
+  disableRedirectOnResultSelect?: boolean;
 }
 
 export interface TokenCheckInputProps {


### PR DESCRIPTION
**Problem**

When the props `redirect` and `mode=results` are passed to the takeover search input widget config (`search-input-binding`), we change the `onSelect` functionality so that when you click on a dropdown result, it will redirect you as specified in the `redirect` prop. 

A customer has asked for the ability to preserve the default functionality that instead redirects you to the product landing page (the `redirect` prop should only apply on a search).  

[EEX-464](https://algolia.atlassian.net/browse/EEX-464)

---
**Solution**

This change allows users to pass a `disableRedirectOnResultSelect` prop to enable the default behaviour of the React SDK input component when `redirect` is present and `mode=results`.

I felt this was a safer bet than changing the expected behaviour of the widgets and/or React SDK `Input` component (e.g., making redirects work for `results` search input widgets) to ensure that other customer implementations won't potentially be affected.

---
**Before**
Redirects to url specified in the `redirect.url` param.

https://github.com/sajari/search-widgets/assets/72959522/4f66af6c-72e4-421e-8a8a-2919fe545880


**After**
Redirects to product landing page.

https://github.com/sajari/search-widgets/assets/72959522/ddbc9e8f-eb22-44f7-b6d4-efd139090c80


