### PR TITLE
feat: add `enableRedirectOnResultsModeSearch` prop to search input widget

### DIFF
--- a/.changeset/clean-tables-fry.md
+++ b/.changeset/clean-tables-fry.md
@@ -1,0 +1,5 @@
+---
+'@sajari/search-widgets': minor
+---
+
+feat: add an `enableRedirectOnResultsModeSearch` search input widget prop to enable redirects to work in results mode

--- a/src/search-input.tsx
+++ b/src/search-input.tsx
@@ -66,6 +66,7 @@ export default (defaultProps: SearchInputProps) => {
     defaultFilter,
     currency,
     customClassNames,
+    enableRedirectOnResultsModeSearch,
   } = defaultProps;
 
   const tracking = getTracking(defaultProps);
@@ -107,6 +108,19 @@ export default (defaultProps: SearchInputProps) => {
 
   if (redirect && mode !== 'results') {
     inputRender = <AutocompleteInput options={options} redirect={redirect} mode={mode} preset={preset} />;
+  } else if (redirect && mode === 'results' && enableRedirectOnResultsModeSearch) {
+    inputRender = (
+      <form action={redirect.url ?? 'search'} css={['font-size: 16px']}>
+        <Input
+          mode={mode}
+          {...options?.input}
+          {...options}
+          name={redirect.queryParamName || 'q'}
+          autoComplete="off"
+          showPoweredBy={showPoweredBy}
+        />
+      </form>
+    );
   } else {
     inputRender = <Input mode={mode} {...options?.input} {...options} showPoweredBy={showPoweredBy} />;
   }

--- a/src/search-input.tsx
+++ b/src/search-input.tsx
@@ -110,7 +110,7 @@ export default (defaultProps: SearchInputProps) => {
     inputRender = <AutocompleteInput options={options} redirect={redirect} mode={mode} preset={preset} />;
   } else if (redirect && mode === 'results' && enableRedirectOnResultsModeSearch) {
     inputRender = (
-      <form action={redirect.url ?? 'search'} css={['font-size: 16px']}>
+      <form action={redirect.url ?? 'search'}>
         <Input
           mode={mode}
           {...options?.input}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -145,6 +145,15 @@ export interface SearchInputProps extends SearchWidgetBaseOptions {
       q: string;
     };
   };
+  // `enableRedirectOnResultsModeSearch` enables redirects to work when using the
+  //  search input in results mode.
+  //
+  // By default, the `redirect` prop is ignored if `mode` is set to `results`.
+  // The reasoning behind this is not clear - it may have been implemented this
+  // way due to a misunderstanding. We're reluctant to change the default behaviour
+  // of the search input as it introduces breaking changes (this change is the result
+  // of a single customer request).
+  enableRedirectOnResultsModeSearch?: boolean;
 }
 
 export interface SearchInputBindingProps extends SearchWidgetBaseOptions, Pick<SearchInputProps, 'mode' | 'redirect'> {


### PR DESCRIPTION
### Problem
Related to previous change: https://github.com/sajari/search-widgets/pull/347

Unfortunately the above change does not resolve the customer issue. I failed to realise that the customer is using an older version of search widgets that doesn't include a bug that was introduced in `3.0.0`, which I didn't account for when testing (sorry 😞).

I've moved the fix to the search input widget, as the takeover search input widget has a bug that stops searches from working when `mode=results`, which will likely take longer to try to fix.

(Ideally, possibly, we would've just told the customer from the get-go that we don't support this functionality, but we seem to have been back and forthing with them enough to justify this low-effort change)

---
### Solution
This change is similar to the last in that it's additive and won't potentially break other customer implementations - I've added an `enableRedirectOnResultsModeSearch` prop that enables redirects to work when the search input widget is set to `results` mode.

If a `redirect` prop is passed, `mode=results` and `enableRedirectOnResultsModeSearch=true`, we'll render the same input we're using now except that it's wrapped in a form with `action=redirect.url`.

---
### Preview
Tested fully this time.

**Current behaviour:**
* Pressing enter to search after typing a value won't do anything (we want this to go to the specified redirect)
* Selecting a result will take you to the product landing page (this is what we want)

Once the `enableRedirectOnResultsModeSearch` is added, you can see that it works as we want (pressing enter to search redirects to "search.html" as specified in the `redirect` prop), and the current behaviour with the result select doesn't change.


https://github.com/sajari/search-widgets/assets/72959522/d5fe8406-6226-4a1a-b6b1-cf05dd2b047c




